### PR TITLE
feat: add GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,41 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run export
+        env:
+          NEXT_PUBLIC_BASE_PATH: "/${{ github.event.repository.name }}"
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: out
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type {NextConfig} from 'next';
 
+// Allow configuring a custom base path when deploying to GitHub Pages.
+// The workflow will set NEXT_PUBLIC_BASE_PATH to "/<repo-name>" so assets resolve correctly.
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+
 const nextConfig: NextConfig = {
   /* config options here */
+  output: 'export',
+  basePath,
+  assetPrefix: basePath,
   typescript: {
     ignoreBuildErrors: true,
   },
@@ -9,6 +16,7 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true,
   },
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "next build",
+    "export": "next build && next export",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary
- configure Next.js for static export and base path
- add export script for building static site
- add GitHub Actions workflow to deploy to GitHub Pages
- update Pages deployment to use latest artifact action

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck` *(fails: property and module errors in TypeScript files)*
- `npm run export` *(fails: dynamic route missing `generateStaticParams()`)*


------
https://chatgpt.com/codex/tasks/task_e_68a9fe7c34408328aabfa30e81794d26