### PR TITLE
Configure app for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## GitHub Pages
+
+This project is configured for static export so it can be hosted on GitHub Pages.
+
+- Run `npm run export` to generate the site in the `out` directory.
+- Pushing to `main` triggers the workflow in `.github/workflows/gh-pages.yml` which builds and deploys the site.
+- Assets are served from a base path using the `NEXT_PUBLIC_BASE_PATH` environment variable.

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,7 @@ const nextConfig: NextConfig = {
   output: 'export',
   basePath,
   assetPrefix: basePath,
+  trailingSlash: true,
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
## Summary
- add trailingSlash to Next.js config for better GitHub Pages support
- document static export workflow for GitHub Pages

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: Property 'get' does not exist on type 'Promise<ReadonlyRequestCookies>' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aadec221dc8328a553d8daa2e2168d