### PR TITLE
Use markdown for posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "firebase": "^12.1.0",
         "genkit": "^1.17.1",
         "lucide-react": "^0.542.0",
+        "marked": "^9.1.6",
         "next": "15.5.0",
         "patch-package": "^8.0.0",
         "react": "^19.1.1",
@@ -10314,6 +10315,18 @@
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
       "dev": true
+    },
+    "node_modules/marked": {
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+      "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "firebase": "^12.1.0",
     "genkit": "^1.17.1",
     "lucide-react": "^0.542.0",
+    "marked": "^9.1.6",
     "next": "15.5.0",
     "patch-package": "^8.0.0",
     "react": "^19.1.1",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ function PostCard({ post }: { post: Post }) {
         <CardContent className="flex-grow">
             <div className="flex items-center text-sm text-muted-foreground">
                 <FileText className="mr-2 h-4 w-4" />
-                <p className="line-clamp-1">{post.fileName}</p>
+                <p className="line-clamp-1">{post.content.split('\n')[0]}</p>
             </div>
         </CardContent>
       </Card>

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,9 +1,10 @@
 import { notFound } from 'next/navigation';
 import { getPost, getPosts } from '@/lib/posts';
 import { Button } from '@/components/ui/button';
-import { Calendar, ArrowLeft, Download } from 'lucide-react';
+import { Calendar, ArrowLeft } from 'lucide-react';
 import Link from 'next/link';
 import { Separator } from '@/components/ui/separator';
+import { marked } from 'marked';
 
 export default async function PostPage({ params }: { params: { slug: string } }) {
   const post = await getPost(params.slug);
@@ -12,9 +13,6 @@ export default async function PostPage({ params }: { params: { slug: string } })
     notFound();
   }
   
-  const isPlaceholder = post.fileName === 'placeholder.txt';
-  const pdfDataUri = `data:application/pdf;base64,${post.content}`;
-
   return (
     <article className="max-w-3xl mx-auto space-y-8 animate-fade-in">
       <div className="space-y-4">
@@ -46,32 +44,10 @@ export default async function PostPage({ params }: { params: { slug: string } })
 
       <Separator />
 
-      <div className="space-y-6">
-        {isPlaceholder ? (
-            <div className="text-lg text-muted-foreground italic p-8 border-2 border-dashed rounded-lg text-center">
-                <p>This is a placeholder post.</p>
-                <p>Edit this post to upload a real PDF file.</p>
-            </div>
-        ) : (
-            <>
-                <div className="text-center">
-                    <Button asChild>
-                        <a href={pdfDataUri} download={post.fileName}>
-                            <Download className="mr-2" />
-                            Download {post.fileName}
-                        </a>
-                    </Button>
-                </div>
-                <div className="aspect-video bg-muted/50 rounded-lg overflow-hidden border">
-                    <iframe
-                        src={pdfDataUri}
-                        className="w-full h-full"
-                        title={`PDF preview for ${post.title}`}
-                    />
-                </div>
-            </>
-        )}
-      </div>
+      <div
+        className="prose dark:prose-invert"
+        dangerouslySetInnerHTML={{ __html: marked.parse(post.content) }}
+      />
     </article>
   );
 }

--- a/src/content/building-interactive-uis-with-next-js.md
+++ b/src/content/building-interactive-uis-with-next-js.md
@@ -1,0 +1,4 @@
+# Building Interactive UIs with Next.js
+
+Next.js combines the power of React with intuitive routing and server-side rendering.
+It enables developers to craft fast, scalable applications with ease.

--- a/src/content/navigating-the-world-of-sans-serif.md
+++ b/src/content/navigating-the-world-of-sans-serif.md
@@ -1,0 +1,4 @@
+# Navigating the World of Sans-Serif
+
+Sans-serif typefaces offer modern aesthetics and excellent readability.
+Choosing the right one can set the tone for your entire design system.

--- a/src/content/the-art-of-minimalist-design.md
+++ b/src/content/the-art-of-minimalist-design.md
@@ -1,0 +1,4 @@
+# The Art of Minimalist Design
+
+Minimalist design strips away the unnecessary to focus on clarity and function.
+It embraces whitespace and clean lines to craft elegant, purposeful interfaces.

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,10 +1,15 @@
+import fs from 'fs';
+import path from 'path';
 import { Post } from '@/lib/types';
+
+// Directory where markdown files are stored
+const postsDir = path.join(process.cwd(), 'src', 'content');
 
 // Using a Map to store posts in memory, simulating a database.
 const posts = new Map<string, Post>();
 
 // Seed the store with some initial blog posts for demonstration.
-const initialPosts: Omit<Post, 'content' | 'fileName'>[] = [
+const initialPosts: Omit<Post, 'content'>[] = [
   {
     id: '1',
     title: 'The Art of Minimalist Design',
@@ -26,10 +31,11 @@ const initialPosts: Omit<Post, 'content' | 'fileName'>[] = [
 ];
 
 initialPosts.forEach(post => {
+  const filePath = path.join(postsDir, `${post.slug}.md`);
+  const content = fs.readFileSync(filePath, 'utf8');
   const fullPost: Post = {
     ...post,
-    content: `This is placeholder content for the post titled "${post.title}". In the real app, this would be a PDF.`,
-    fileName: 'placeholder.txt',
+    content,
   };
   posts.set(post.slug, fullPost);
 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,6 @@ export interface Post {
   id: string;
   slug: string;
   title: string;
-  content: string; // Will store PDF data as base64 string
-  fileName: string; // To store the original file name
+  content: string; // Markdown content
   publishedAt: Date;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["react"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- swap in-memory PDF approach for markdown-based posts
- render markdown content with marked and show previews on the home page
- seed repository with sample markdown posts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ae082077d88328af3dd56c9d01c33f