### PR TITLE
feat: add hero and footer for better layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { Header } from '@/components/header';
+import { Footer } from '@/components/footer';
 import { Toaster } from '@/components/ui/toaster';
 import { cn } from '@/lib/utils';
 import { Noto_Serif, Fira_Code } from 'next/font/google';
@@ -33,6 +34,7 @@ export default function RootLayout({
         <main className="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
           {children}
         </main>
+        <Footer />
         <Toaster />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,8 +34,15 @@ export default async function Home() {
 
   return (
     <div className="space-y-8 animate-fade-in">
+      <section className="text-center py-10 md:py-16 bg-gradient-to-b from-background to-muted rounded-lg">
+        <h1 className="text-4xl md:text-5xl font-bold mb-4">Welcome to StaesBlog</h1>
+        <p className="text-muted-foreground max-w-2xl mx-auto">
+          Exploring minimalist thoughts with modern web tech.
+        </p>
+      </section>
+
       <div className="flex justify-between items-center gap-4">
-        <h1 className="text-3xl md:text-4xl font-bold font-headline text-primary">Latest Posts</h1>
+        <h2 className="text-3xl md:text-4xl font-bold font-headline text-primary">Latest Posts</h2>
       </div>
 
       {posts.length === 0 ? (

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,0 +1,11 @@
+export function Footer() {
+  return (
+    <footer className="bg-card/80 backdrop-blur-sm border-t mt-8">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 text-center text-sm text-muted-foreground">
+        <p>&copy; {new Date().getFullYear()} StaesBlog. All rights reserved.</p>
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;


### PR DESCRIPTION
## Summary
- add global footer for consistent branding
- introduce hero section on homepage with gradient and intro text

## Testing
- `npm run lint` *(fails: prompted for ESLint configuration)*
- `npm run typecheck` *(fails: Cannot find module 'marked' or its types)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0cb2f45c8328a317caea7018e27c