### PR TITLE
feat: modernize UI design

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,57 +9,57 @@
 
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
- 
+
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
- 
-    --primary: 222.2 47.4% 11.2%;
+
+    --primary: 262 83% 57%;
     --primary-foreground: 210 40% 98%;
- 
+
     --secondary: 210 40% 96.1%;
     --secondary-foreground: 222.2 47.4% 11.2%;
- 
+
     --muted: 210 40% 96.1%;
     --muted-foreground: 215.4 16.3% 46.9%;
- 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
- 
+
+    --accent: 168 83% 45%;
+    --accent-foreground: 210 40% 98%;
+
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
     --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
- 
+
     --radius: 0.5rem;
   }
- 
+
   .dark {
-    --background: 240 5% 15%;
+    --background: 230 25% 10%;
     --foreground: 210 40% 98%;
- 
-    --card: 240 5% 15%;
+
+    --card: 230 25% 10%;
     --card-foreground: 210 40% 98%;
- 
+
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
- 
-    --primary: 220 60% 40%;
-    --primary-foreground: 210 40% 98%;
- 
+
+    --primary: 262 83% 70%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
- 
+
     --muted: 217.2 32.6% 17.5%;
     --muted-foreground: 215 20.2% 65.1%;
- 
-    --accent: 220 60% 40%;
-    --accent-foreground: 210 40% 98%;
- 
+
+    --accent: 168 83% 65%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
- 
+
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
     --ring: 212.7 26.8% 83.9%;
@@ -94,5 +94,8 @@
   }
   body {
     @apply bg-background text-foreground;
+    background-image:
+      radial-gradient(circle at 20% 20%, hsl(var(--primary) / 0.15), transparent 60%),
+      radial-gradient(circle at 80% 80%, hsl(var(--accent) / 0.15), transparent 60%);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,11 +4,16 @@ import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
 import { Toaster } from '@/components/ui/toaster';
 import { cn } from '@/lib/utils';
-import { Noto_Serif, Fira_Code } from 'next/font/google';
+import { Inter, Playfair_Display, Fira_Code } from 'next/font/google';
 
-const notoSerif = Noto_Serif({
+const inter = Inter({
   subsets: ['latin'],
-  variable: '--font-noto-serif',
+  variable: '--font-inter',
+});
+
+const playfair = Playfair_Display({
+  subsets: ['latin'],
+  variable: '--font-playfair',
 });
 
 const firaCode = Fira_Code({
@@ -29,7 +34,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="h-full dark">
-      <body className={cn('font-body antialiased h-full flex flex-col', notoSerif.variable, firaCode.variable)}>
+      <body
+        className={cn(
+          'font-body antialiased min-h-screen flex flex-col bg-gradient-to-br from-background via-background to-muted',
+          inter.variable,
+          playfair.variable,
+          firaCode.variable,
+        )}
+      >
         <Header />
         <main className="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
           {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,16 @@
 import Link from 'next/link';
 import { getPosts } from '@/lib/posts';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
-import { FileText } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ArrowRight, FileText } from 'lucide-react';
 import { Post } from '@/lib/types';
 
 function PostCard({ post }: { post: Post }) {
   return (
     <Link href={`/posts/${post.slug}`} className="group block h-full">
-      <Card className="h-full flex flex-col transition-all duration-300 ease-in-out group-hover:shadow-xl group-hover:-translate-y-1.5 border-2 border-border hover:border-accent">
+      <Card className="h-full flex flex-col bg-card/60 backdrop-blur-sm transition-all duration-300 ease-in-out group-hover:shadow-2xl group-hover:-translate-y-1 border border-border hover:border-primary">
         <CardHeader>
-          <CardTitle className="group-hover:text-accent transition-colors">{post.title}</CardTitle>
+          <CardTitle className="transition-colors group-hover:text-primary">{post.title}</CardTitle>
           <CardDescription>
             {new Date(post.publishedAt).toLocaleDateString('en-US', {
               year: 'numeric',
@@ -33,22 +34,30 @@ export default async function Home() {
   const posts = await getPosts();
 
   return (
-    <div className="space-y-8 animate-fade-in">
-      <section className="text-center py-10 md:py-16 bg-gradient-to-b from-background to-muted rounded-lg">
-        <h1 className="text-4xl md:text-5xl font-bold mb-4">Welcome to StaesBlog</h1>
-        <p className="text-muted-foreground max-w-2xl mx-auto">
+    <div className="space-y-12 animate-fade-in">
+      <section className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-primary/20 via-background to-background py-16 text-center md:py-24">
+        <h1 className="mb-6 bg-gradient-to-r from-primary to-accent bg-clip-text text-5xl font-extrabold text-transparent md:text-6xl">
+          Welcome to StaesBlog
+        </h1>
+        <p className="mx-auto mb-8 max-w-2xl text-muted-foreground">
           Exploring minimalist thoughts with modern web tech.
         </p>
+        <Button asChild size="lg" className="group">
+          <Link href="#latest-posts">
+            Read Posts
+            <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
+          </Link>
+        </Button>
       </section>
 
-      <div className="flex justify-between items-center gap-4">
-        <h2 className="text-3xl md:text-4xl font-bold font-headline text-primary">Latest Posts</h2>
+      <div id="latest-posts" className="flex items-center justify-between gap-4">
+        <h2 className="font-headline text-3xl font-bold text-primary md:text-4xl">Latest Posts</h2>
       </div>
 
       {posts.length === 0 ? (
-        <div className="text-center py-20 px-4 border-2 border-dashed rounded-lg bg-card">
+        <div className="text-center py-20 px-4 border-2 border-dashed rounded-lg bg-card/60 backdrop-blur-sm">
           <h2 className="text-xl font-medium">No posts yet</h2>
-          <p className="text-muted-foreground mt-2 mb-4">Start by creating your first post.</p>
+          <p className="mt-2 mb-4 text-muted-foreground">Start by creating your first post.</p>
         </div>
       ) : (
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -14,18 +14,21 @@ export default async function PostPage({ params }: { params: { slug: string } })
   }
   
   return (
-    <article className="max-w-3xl mx-auto space-y-8 animate-fade-in">
+    <article className="mx-auto max-w-3xl space-y-8 rounded-2xl bg-card/60 p-8 backdrop-blur-sm animate-fade-in">
       <div className="space-y-4">
-        <div className="flex justify-between items-start gap-4">
-            <Button variant="ghost" size="sm" asChild className="-ml-4">
-                <Link href="/" className="inline-flex items-center text-muted-foreground hover:text-foreground transition-colors">
-                    <ArrowLeft className="mr-2 h-4 w-4" />
-                    All Posts
-                </Link>
-            </Button>
+        <div className="flex items-start justify-between gap-4">
+          <Button variant="ghost" size="sm" asChild className="-ml-4">
+            <Link
+              href="/"
+              className="inline-flex items-center text-muted-foreground transition-colors hover:text-primary"
+            >
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              All Posts
+            </Link>
+          </Button>
         </div>
 
-        <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight font-headline text-primary">
+        <h1 className="bg-gradient-to-r from-primary to-accent bg-clip-text text-4xl font-extrabold tracking-tight text-transparent md:text-5xl font-headline">
           {post.title}
         </h1>
 

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,8 +1,10 @@
 export function Footer() {
   return (
-    <footer className="bg-card/80 backdrop-blur-sm border-t mt-8">
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 text-center text-sm text-muted-foreground">
-        <p>&copy; {new Date().getFullYear()} StaesBlog. All rights reserved.</p>
+    <footer className="mt-12 border-t bg-background/60 backdrop-blur-xl">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center text-sm text-muted-foreground">
+        <p>
+          &copy; {new Date().getFullYear()} StaesBlog. Built with Next.js &amp; Tailwind CSS.
+        </p>
       </div>
     </footer>
   );

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,18 +3,24 @@ import { BookText } from 'lucide-react';
 
 export function Header() {
   return (
-    <header className="bg-card/80 backdrop-blur-sm border-b sticky top-0 z-50">
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex items-center justify-between h-16">
-          <Link href="/" className="flex items-center gap-2 group">
-            <div className="p-2 rounded-full bg-primary text-primary-foreground group-hover:bg-primary/90 transition-colors">
-              <BookText className="h-5 w-5" />
-            </div>
-            <h1 className="text-xl font-bold font-headline text-foreground group-hover:text-foreground/80 transition-colors sm:text-2xl">
-              StaesBlog
-            </h1>
+    <header className="sticky top-0 z-50 border-b bg-background/60 backdrop-blur-xl">
+      <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
+        <Link href="/" className="flex items-center gap-2">
+          <div className="rounded-full bg-gradient-to-r from-primary to-accent p-2 text-primary-foreground">
+            <BookText className="h-5 w-5" />
+          </div>
+          <span className="bg-gradient-to-r from-primary to-accent bg-clip-text text-xl font-bold text-transparent sm:text-2xl">
+            StaesBlog
+          </span>
+        </Link>
+        <nav className="hidden gap-6 text-sm font-medium sm:flex">
+          <Link href="/" className="transition-colors hover:text-primary">
+            Home
           </Link>
-        </div>
+          <Link href="#latest-posts" className="transition-colors hover:text-primary">
+            Posts
+          </Link>
+        </nav>
       </div>
     </header>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,8 +10,8 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        body: ['var(--font-noto-serif)', 'serif'],
-        headline: ['var(--font-noto-serif)', 'serif'],
+        body: ['var(--font-inter)', 'sans-serif'],
+        headline: ['var(--font-playfair)', 'serif'],
         code: ['var(--font-fira-code)', 'monospace'],
       },
       colors: {


### PR DESCRIPTION
## Summary
- refresh global color palette and add subtle gradient background
- upgrade typography and layout with Inter and Playfair fonts
- redesign header, footer, home, and post pages with modern components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aeacafbd6c8328aa2e4d51f045ce8d