### PR TITLE
Revamp UI with dark theme and animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "dotenv": "^17.2.1",
         "embla-carousel-react": "^8.6.0",
         "firebase": "^12.1.0",
+        "framer-motion": "^11.0.0",
         "genkit": "^1.17.1",
         "lucide-react": "^0.542.0",
         "marked": "^9.1.6",
@@ -8567,6 +8568,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -10490,6 +10518,21 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "react-hook-form": "^7.62.0",
     "recharts": "^3.1.2",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "framer-motion": "^11.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -97,5 +97,19 @@
     background-image:
       radial-gradient(circle at 20% 20%, hsl(var(--primary) / 0.15), transparent 60%),
       radial-gradient(circle at 80% 80%, hsl(var(--accent) / 0.15), transparent 60%);
+    background-size: 200% 200%;
+    animation: gradient-move 15s ease infinite;
+  }
+}
+
+@keyframes gradient-move {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,54 +1,13 @@
-import Link from 'next/link';
 import { getPosts } from '@/lib/posts';
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { ArrowRight, FileText } from 'lucide-react';
-import { Post } from '@/lib/types';
-
-function PostCard({ post }: { post: Post }) {
-  return (
-    <Link href={`/posts/${post.slug}`} className="group block h-full">
-      <Card className="h-full flex flex-col bg-card/60 backdrop-blur-sm transition-all duration-300 ease-in-out group-hover:shadow-2xl group-hover:-translate-y-1 border border-border hover:border-primary">
-        <CardHeader>
-          <CardTitle className="transition-colors group-hover:text-primary">{post.title}</CardTitle>
-          <CardDescription>
-            {new Date(post.publishedAt).toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex-grow">
-            <div className="flex items-center text-sm text-muted-foreground">
-                <FileText className="mr-2 h-4 w-4" />
-                <p className="line-clamp-1">{post.content.split('\n')[0]}</p>
-            </div>
-        </CardContent>
-      </Card>
-    </Link>
-  )
-}
+import { Hero } from '@/components/hero';
+import { PostCard } from '@/components/post-card';
 
 export default async function Home() {
   const posts = await getPosts();
 
   return (
     <div className="space-y-12 animate-fade-in">
-      <section className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-primary/20 via-background to-background py-16 text-center md:py-24">
-        <h1 className="mb-6 bg-gradient-to-r from-primary to-accent bg-clip-text text-5xl font-extrabold text-transparent md:text-6xl">
-          Welcome to StaesBlog
-        </h1>
-        <p className="mx-auto mb-8 max-w-2xl text-muted-foreground">
-          Exploring minimalist thoughts with modern web tech.
-        </p>
-        <Button asChild size="lg" className="group">
-          <Link href="#latest-posts">
-            Read Posts
-            <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
-          </Link>
-        </Button>
-      </section>
+      <Hero />
 
       <div id="latest-posts" className="flex items-center justify-between gap-4">
         <h2 className="font-headline text-3xl font-bold text-primary md:text-4xl">Latest Posts</h2>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,13 +1,21 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
 export function Footer() {
   return (
-    <footer className="mt-12 border-t bg-background/60 backdrop-blur-xl">
+    <motion.footer
+      initial={{ opacity: 0 }}
+      whileInView={{ opacity: 1 }}
+      viewport={{ once: true }}
+      className="mt-12 border-t bg-background/80 backdrop-blur-lg"
+    >
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center text-sm text-muted-foreground">
-        <p>
-          &copy; {new Date().getFullYear()} StaesBlog. Built with Next.js &amp; Tailwind CSS.
-        </p>
+        <p>&copy; {new Date().getFullYear()} StaesBlog. Built with Next.js &amp; Tailwind CSS.</p>
       </div>
-    </footer>
+    </motion.footer>
   );
 }
 
 export default Footer;
+

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,27 +1,46 @@
+'use client';
+
 import Link from 'next/link';
+import { motion } from 'framer-motion';
 import { BookText } from 'lucide-react';
 
 export function Header() {
   return (
-    <header className="sticky top-0 z-50 border-b bg-background/60 backdrop-blur-xl">
+    <motion.header
+      initial={{ y: -80, opacity: 0 }}
+      animate={{ y: 0, opacity: 1 }}
+      transition={{ duration: 0.6, ease: 'easeOut' }}
+      className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-lg"
+    >
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link href="/" className="flex items-center gap-2">
-          <div className="rounded-full bg-gradient-to-r from-primary to-accent p-2 text-primary-foreground">
+          <motion.div
+            whileHover={{ rotate: 360 }}
+            transition={{ duration: 0.8 }}
+            className="rounded-full bg-gradient-to-r from-primary to-accent p-2 text-primary-foreground"
+          >
             <BookText className="h-5 w-5" />
-          </div>
+          </motion.div>
           <span className="bg-gradient-to-r from-primary to-accent bg-clip-text text-xl font-bold text-transparent sm:text-2xl">
             StaesBlog
           </span>
         </Link>
         <nav className="hidden gap-6 text-sm font-medium sm:flex">
-          <Link href="/" className="transition-colors hover:text-primary">
-            Home
-          </Link>
-          <Link href="#latest-posts" className="transition-colors hover:text-primary">
-            Posts
-          </Link>
+          <motion.span whileHover={{ scale: 1.1 }}>
+            <Link href="/" className="transition-colors hover:text-primary">
+              Home
+            </Link>
+          </motion.span>
+          <motion.span whileHover={{ scale: 1.1 }}>
+            <Link href="#latest-posts" className="transition-colors hover:text-primary">
+              Posts
+            </Link>
+          </motion.span>
         </nav>
       </div>
-    </header>
+    </motion.header>
   );
 }
+
+export default Header;
+

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { ArrowRight } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+export function Hero() {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.8 }}
+      className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-primary/20 via-background to-background py-16 text-center md:py-24"
+    >
+      <motion.h1
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.2 }}
+        className="mb-6 bg-gradient-to-r from-primary to-accent bg-clip-text text-5xl font-extrabold text-transparent md:text-6xl"
+      >
+        Welcome to StaesBlog
+      </motion.h1>
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.4 }}
+        className="mx-auto mb-8 max-w-2xl text-muted-foreground"
+      >
+        Exploring minimalist thoughts with modern web tech.
+      </motion.p>
+      <Button asChild size="lg" className="group">
+        <Link href="#latest-posts">
+          Read Posts
+          <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
+        </Link>
+      </Button>
+    </motion.section>
+  );
+}
+
+export default Hero;
+

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+import { motion } from 'framer-motion';
+import { FileText } from 'lucide-react';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Post } from '@/lib/types';
+
+export function PostCard({ post }: { post: Post }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      whileHover={{ scale: 1.03 }}
+      transition={{ duration: 0.3 }}
+      className="h-full"
+    >
+      <Link href={`/posts/${post.slug}`} className="group block h-full">
+        <Card className="h-full flex flex-col bg-card/60 backdrop-blur-sm transition-all duration-300 ease-in-out group-hover:shadow-2xl group-hover:-translate-y-1 border border-border hover:border-primary">
+          <CardHeader>
+            <CardTitle className="transition-colors group-hover:text-primary">{post.title}</CardTitle>
+            <CardDescription>
+              {new Date(post.publishedAt).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex-grow">
+            <div className="flex items-center text-sm text-muted-foreground">
+              <FileText className="mr-2 h-4 w-4" />
+              <p className="line-clamp-1">{post.content.split('\n')[0]}</p>
+            </div>
+          </CardContent>
+        </Card>
+      </Link>
+    </motion.div>
+  );
+}
+
+export default PostCard;
+


### PR DESCRIPTION
## Summary
- add framer-motion dependency for rich animations
- redesign header, footer, and home page with modern dark-mode components
- animate background and post cards for a dynamic experience

## Testing
- `npm run lint` *(fails: prompts for interactive ESLint setup)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aeb4dc8d2083288e4d67d96225c233