### PR TITLE
feat: apply clean dark theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "dotenv": "^17.2.1",
         "embla-carousel-react": "^8.6.0",
         "firebase": "^12.1.0",
-        "framer-motion": "^11.0.0",
         "genkit": "^1.17.1",
         "lucide-react": "^0.542.0",
         "marked": "^9.1.6",
@@ -6086,6 +6085,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.12.tgz",
@@ -8568,33 +8627,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/framer-motion": {
-      "version": "11.18.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
-      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^11.18.1",
-        "motion-utils": "^11.18.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -10518,21 +10550,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-      "license": "MIT"
-    },
-    "node_modules/motion-dom": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
-      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^11.18.1"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
-      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "react-hook-form": "^7.62.0",
     "recharts": "^3.1.2",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7",
-    "framer-motion": "^11.0.0"
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,33 +36,33 @@
   }
 
   .dark {
-    --background: 230 25% 10%;
-    --foreground: 210 40% 98%;
+    --background: 222 47% 11%;
+    --foreground: 0 0% 98%;
 
-    --card: 230 25% 10%;
-    --card-foreground: 210 40% 98%;
+    --card: 222 47% 15%;
+    --card-foreground: 0 0% 98%;
 
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
+    --popover: 222 47% 15%;
+    --popover-foreground: 0 0% 98%;
 
-    --primary: 262 83% 70%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 210 100% 50%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 217 33% 17%;
+    --secondary-foreground: 0 0% 98%;
 
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 217 33% 17%;
+    --muted-foreground: 215 20% 65%;
 
-    --accent: 168 83% 65%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 210 100% 60%;
+    --accent-foreground: 0 0% 98%;
 
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 62% 30%;
+    --destructive-foreground: 0 0% 98%;
 
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --border: 217 33% 17%;
+    --input: 217 33% 17%;
+    --ring: 222 47% 11%;
   }
 }
 
@@ -94,22 +94,5 @@
   }
   body {
     @apply bg-background text-foreground;
-    background-image:
-      radial-gradient(circle at 20% 20%, hsl(var(--primary) / 0.15), transparent 60%),
-      radial-gradient(circle at 80% 80%, hsl(var(--accent) / 0.15), transparent 60%);
-    background-size: 200% 200%;
-    animation: gradient-move 15s ease infinite;
-  }
-}
-
-@keyframes gradient-move {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
-import { Toaster } from '@/components/ui/toaster';
 import { cn } from '@/lib/utils';
 import { Inter, Playfair_Display, Fira_Code } from 'next/font/google';
 
@@ -36,7 +35,7 @@ export default function RootLayout({
     <html lang="en" className="h-full dark">
       <body
         className={cn(
-          'font-body antialiased min-h-screen flex flex-col bg-gradient-to-br from-background via-background to-muted',
+          'font-body antialiased min-h-screen flex flex-col bg-background',
           inter.variable,
           playfair.variable,
           firaCode.variable,
@@ -47,7 +46,6 @@ export default function RootLayout({
           {children}
         </main>
         <Footer />
-        <Toaster />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ export default async function Home() {
   const posts = await getPosts();
 
   return (
-    <div className="space-y-12 animate-fade-in">
+    <div className="space-y-12">
       <Hero />
 
       <div id="latest-posts" className="flex items-center justify-between gap-4">
@@ -14,7 +14,7 @@ export default async function Home() {
       </div>
 
       {posts.length === 0 ? (
-        <div className="text-center py-20 px-4 border-2 border-dashed rounded-lg bg-card/60 backdrop-blur-sm">
+        <div className="text-center py-20 px-4 border-2 border-dashed rounded-lg bg-card">
           <h2 className="text-xl font-medium">No posts yet</h2>
           <p className="mt-2 mb-4 text-muted-foreground">Start by creating your first post.</p>
         </div>

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -14,7 +14,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
   }
   
   return (
-    <article className="mx-auto max-w-3xl space-y-8 rounded-2xl bg-card/60 p-8 backdrop-blur-sm animate-fade-in">
+    <article className="mx-auto max-w-3xl space-y-8 rounded-2xl bg-card p-8">
       <div className="space-y-4">
         <div className="flex items-start justify-between gap-4">
           <Button variant="ghost" size="sm" asChild className="-ml-4">
@@ -28,7 +28,7 @@ export default async function PostPage({ params }: { params: { slug: string } })
           </Button>
         </div>
 
-        <h1 className="bg-gradient-to-r from-primary to-accent bg-clip-text text-4xl font-extrabold tracking-tight text-transparent md:text-5xl font-headline">
+        <h1 className="text-4xl font-extrabold tracking-tight md:text-5xl font-headline text-primary">
           {post.title}
         </h1>
 

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,19 +1,12 @@
-'use client';
-
-import { motion } from 'framer-motion';
+import React from 'react';
 
 export function Footer() {
   return (
-    <motion.footer
-      initial={{ opacity: 0 }}
-      whileInView={{ opacity: 1 }}
-      viewport={{ once: true }}
-      className="mt-12 border-t bg-background/80 backdrop-blur-lg"
-    >
+    <footer className="mt-12 border-t bg-background">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center text-sm text-muted-foreground">
         <p>&copy; {new Date().getFullYear()} StaesBlog. Built with Next.js &amp; Tailwind CSS.</p>
       </div>
-    </motion.footer>
+    </footer>
   );
 }
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,44 +1,24 @@
-'use client';
-
 import Link from 'next/link';
-import { motion } from 'framer-motion';
 import { BookText } from 'lucide-react';
 
 export function Header() {
   return (
-    <motion.header
-      initial={{ y: -80, opacity: 0 }}
-      animate={{ y: 0, opacity: 1 }}
-      transition={{ duration: 0.6, ease: 'easeOut' }}
-      className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-lg"
-    >
+    <header className="border-b bg-background">
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link href="/" className="flex items-center gap-2">
-          <motion.div
-            whileHover={{ rotate: 360 }}
-            transition={{ duration: 0.8 }}
-            className="rounded-full bg-gradient-to-r from-primary to-accent p-2 text-primary-foreground"
-          >
-            <BookText className="h-5 w-5" />
-          </motion.div>
-          <span className="bg-gradient-to-r from-primary to-accent bg-clip-text text-xl font-bold text-transparent sm:text-2xl">
-            StaesBlog
-          </span>
+          <BookText className="h-5 w-5 text-primary" />
+          <span className="text-xl font-bold sm:text-2xl">StaesBlog</span>
         </Link>
         <nav className="hidden gap-6 text-sm font-medium sm:flex">
-          <motion.span whileHover={{ scale: 1.1 }}>
-            <Link href="/" className="transition-colors hover:text-primary">
-              Home
-            </Link>
-          </motion.span>
-          <motion.span whileHover={{ scale: 1.1 }}>
-            <Link href="#latest-posts" className="transition-colors hover:text-primary">
-              Posts
-            </Link>
-          </motion.span>
+          <Link href="/" className="hover:text-primary">
+            Home
+          </Link>
+          <Link href="#latest-posts" className="hover:text-primary">
+            Posts
+          </Link>
         </nav>
       </div>
-    </motion.header>
+    </header>
   );
 }
 

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -1,41 +1,21 @@
-'use client';
-
 import Link from 'next/link';
-import { motion } from 'framer-motion';
 import { ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 export function Hero() {
   return (
-    <motion.section
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.8 }}
-      className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-primary/20 via-background to-background py-16 text-center md:py-24"
-    >
-      <motion.h1
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.2 }}
-        className="mb-6 bg-gradient-to-r from-primary to-accent bg-clip-text text-5xl font-extrabold text-transparent md:text-6xl"
-      >
-        Welcome to StaesBlog
-      </motion.h1>
-      <motion.p
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 0.4 }}
-        className="mx-auto mb-8 max-w-2xl text-muted-foreground"
-      >
+    <section className="py-16 text-center md:py-24">
+      <h1 className="mb-6 text-5xl font-extrabold md:text-6xl">Welcome to StaesBlog</h1>
+      <p className="mx-auto mb-8 max-w-2xl text-muted-foreground">
         Exploring minimalist thoughts with modern web tech.
-      </motion.p>
-      <Button asChild size="lg" className="group">
+      </p>
+      <Button asChild size="lg">
         <Link href="#latest-posts">
           Read Posts
-          <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
+          <ArrowRight className="ml-2 h-4 w-4" />
         </Link>
       </Button>
-    </motion.section>
+    </section>
   );
 }
 

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -1,42 +1,30 @@
-'use client';
-
 import Link from 'next/link';
-import { motion } from 'framer-motion';
 import { FileText } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Post } from '@/lib/types';
 
 export function PostCard({ post }: { post: Post }) {
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      whileHover={{ scale: 1.03 }}
-      transition={{ duration: 0.3 }}
-      className="h-full"
-    >
-      <Link href={`/posts/${post.slug}`} className="group block h-full">
-        <Card className="h-full flex flex-col bg-card/60 backdrop-blur-sm transition-all duration-300 ease-in-out group-hover:shadow-2xl group-hover:-translate-y-1 border border-border hover:border-primary">
-          <CardHeader>
-            <CardTitle className="transition-colors group-hover:text-primary">{post.title}</CardTitle>
-            <CardDescription>
-              {new Date(post.publishedAt).toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex-grow">
-            <div className="flex items-center text-sm text-muted-foreground">
-              <FileText className="mr-2 h-4 w-4" />
-              <p className="line-clamp-1">{post.content.split('\n')[0]}</p>
-            </div>
-          </CardContent>
-        </Card>
-      </Link>
-    </motion.div>
+    <Link href={`/posts/${post.slug}`} className="block h-full">
+      <Card className="h-full flex flex-col">
+        <CardHeader>
+          <CardTitle>{post.title}</CardTitle>
+          <CardDescription>
+            {new Date(post.publishedAt).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex-grow">
+          <div className="flex items-center text-sm text-muted-foreground">
+            <FileText className="mr-2 h-4 w-4" />
+            <p className="line-clamp-1">{post.content.split('\n')[0]}</p>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
   );
 }
 


### PR DESCRIPTION
## Summary
- apply classic dark theme variables and remove gradient background
- simplify header, hero, post card, and post pages
- drop framer-motion dependency and unused toaster

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b53d03c2088328928ad19e25c13ccf