### PR TITLE
Add retro dark front page and remove header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import './globals.css';
-import { Header } from '@/components/header';
 import { Footer } from '@/components/footer';
 import { cn } from '@/lib/utils';
 import { Inter, Playfair_Display, Fira_Code } from 'next/font/google';
@@ -41,7 +40,6 @@ export default function RootLayout({
           firaCode.variable,
         )}
       >
-        <Header />
         <main className="flex-grow container mx-auto px-4 sm:px-6 lg:px-8 py-8 md:py-12">
           {children}
         </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,30 +1,20 @@
-import { getPosts } from '@/lib/posts';
-import { Hero } from '@/components/hero';
-import { PostCard } from '@/components/post-card';
-
-export default async function Home() {
-  const posts = await getPosts();
+export default function Home() {
+  const marquee = '<marquee class="mb-8">Welcome to the dark side of 1998</marquee>';
 
   return (
-    <div className="space-y-12">
-      <Hero />
-
-      <div id="latest-posts" className="flex items-center justify-between gap-4">
-        <h2 className="font-headline text-3xl font-bold text-primary md:text-4xl">Latest Posts</h2>
-      </div>
-
-      {posts.length === 0 ? (
-        <div className="text-center py-20 px-4 border-2 border-dashed rounded-lg bg-card">
-          <h2 className="text-xl font-medium">No posts yet</h2>
-          <p className="mt-2 mb-4 text-muted-foreground">Start by creating your first post.</p>
-        </div>
-      ) : (
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {posts.map((post) => (
-            <PostCard key={post.slug} post={post} />
-          ))}
-        </div>
-      )}
+    <div className="min-h-screen bg-black text-green-400 p-8 font-mono">
+      <center>
+        <h1 className="text-4xl mb-4">StaesBlog</h1>
+        <div dangerouslySetInnerHTML={{ __html: marquee }} />
+        <p>
+          <a href="/posts" className="underline hover:text-green-300">
+            Enter the blog
+          </a>
+        </p>
+      </center>
+      <hr className="my-8 border-green-400" />
+      <p className="text-sm">Best viewed with Netscape Navigator.</p>
     </div>
   );
 }
+

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,0 +1,31 @@
+import { getPosts } from '@/lib/posts';
+import { Hero } from '@/components/hero';
+import { PostCard } from '@/components/post-card';
+
+export default async function PostsPage() {
+  const posts = await getPosts();
+
+  return (
+    <div className="space-y-12">
+      <Hero />
+
+      <div id="latest-posts" className="flex items-center justify-between gap-4">
+        <h2 className="font-headline text-3xl font-bold text-primary md:text-4xl">Latest Posts</h2>
+      </div>
+
+      {posts.length === 0 ? (
+        <div className="text-center py-20 px-4 border-2 border-dashed rounded-lg bg-card">
+          <h2 className="text-xl font-medium">No posts yet</h2>
+          <p className="mt-2 mb-4 text-muted-foreground">Start by creating your first post.</p>
+        </div>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {posts.map((post) => (
+            <PostCard key={post.slug} post={post} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Drop site header for a cleaner layout
- Create a dark, retro-style landing page with marquee intro
- Move modern post list to new `/posts` route

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c18076f48328b5096f1a9e02088e