### PR TITLE
Use Next.js Link for blog entry navigation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export default function Home() {
   const marquee = '<marquee class="mb-8">Welcome to the dark side of 1998</marquee>';
 
@@ -7,9 +9,9 @@ export default function Home() {
         <h1 className="text-4xl mb-4">StaesBlog</h1>
         <div dangerouslySetInnerHTML={{ __html: marquee }} />
         <p>
-          <a href="/posts" className="underline hover:text-green-300">
+          <Link href="/posts" className="underline hover:text-green-300">
             Enter the blog
-          </a>
+          </Link>
         </p>
       </center>
       <hr className="my-8 border-green-400" />


### PR DESCRIPTION
## Summary
- fix broken "Enter the blog" navigation by using Next.js `Link`

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b9384996208328afcdbb892edb7194