### PR TITLE
Improve post menu styling and remove duplicate titles

### DIFF
--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -6,10 +6,10 @@ export default async function PostsPage() {
   const posts = await getPosts();
 
   return (
-    <div className="space-y-12">
+    <div className="space-y-12 max-w-5xl mx-auto px-4">
       <Hero />
 
-      <div id="latest-posts" className="flex items-center justify-between gap-4">
+      <div id="latest-posts" className="mb-6 flex items-center justify-between gap-4">
         <h2 className="font-headline text-3xl font-bold text-primary md:text-4xl">Latest Posts</h2>
       </div>
 
@@ -19,7 +19,7 @@ export default async function PostsPage() {
           <p className="mt-2 mb-4 text-muted-foreground">Start by creating your first post.</p>
         </div>
       ) : (
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {posts.map((post) => (
             <PostCard key={post.slug} post={post} />
           ))}

--- a/src/components/post-card.tsx
+++ b/src/components/post-card.tsx
@@ -1,14 +1,18 @@
 import Link from 'next/link';
-import { FileText } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Post } from '@/lib/types';
 
 export function PostCard({ post }: { post: Post }) {
+  const snippet = post.content
+    .split('\n')
+    .find((line) => line.trim() && !line.trim().startsWith('#'))
+    ?.trim();
+
   return (
     <Link href={`/posts/${post.slug}`} className="block h-full">
-      <Card className="h-full flex flex-col">
+      <Card className="h-full flex flex-col transition-shadow hover:shadow-md">
         <CardHeader>
-          <CardTitle>{post.title}</CardTitle>
+          <CardTitle className="text-xl font-semibold">{post.title}</CardTitle>
           <CardDescription>
             {new Date(post.publishedAt).toLocaleDateString('en-US', {
               year: 'numeric',
@@ -17,12 +21,11 @@ export function PostCard({ post }: { post: Post }) {
             })}
           </CardDescription>
         </CardHeader>
-        <CardContent className="flex-grow">
-          <div className="flex items-center text-sm text-muted-foreground">
-            <FileText className="mr-2 h-4 w-4" />
-            <p className="line-clamp-1">{post.content.split('\n')[0]}</p>
-          </div>
-        </CardContent>
+        {snippet && (
+          <CardContent className="flex-grow">
+            <p className="text-sm text-muted-foreground line-clamp-2">{snippet}</p>
+          </CardContent>
+        )}
       </Card>
     </Link>
   );


### PR DESCRIPTION
## Summary
- Avoid showing post title twice by displaying first non-heading line in card preview
- Center and space the post list grid for a cleaner layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb5310ad488328b0c6c3f5c2829c51