### PR TITLE
Add admin login and markdown upload feature

### DIFF
--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+export default function AdminLoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (username === 'admin' && password === 'password') {
+      localStorage.setItem('isAdmin', 'true');
+      router.push('/admin/upload');
+    } else {
+      alert('Invalid credentials');
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-md space-y-6">
+      <h1 className="text-2xl font-bold">Admin Login</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <Input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <Button type="submit" className="w-full">
+          Login
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/admin/upload/page.tsx
+++ b/src/app/admin/upload/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+export default function UploadPage() {
+  const router = useRouter();
+  const [file, setFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    if (localStorage.getItem('isAdmin') !== 'true') {
+      router.push('/admin/login');
+    }
+  }, [router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch('/api/upload', {
+      method: 'POST',
+      body: formData,
+    });
+    if (res.ok) {
+      alert('Post uploaded');
+      router.push('/');
+    } else {
+      alert('Upload failed');
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-md space-y-6">
+      <h1 className="text-2xl font-bold">Upload Markdown Post</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <Input
+          type="file"
+          accept=".md"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        />
+        <Button type="submit" className="w-full">
+          Upload
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { writeFile } from 'fs/promises';
+import path from 'path';
+import { addPost } from '@/lib/posts';
+
+export async function POST(request: NextRequest) {
+  const data = await request.formData();
+  const file = data.get('file') as File | null;
+
+  if (!file) {
+    return NextResponse.json({ error: 'No file uploaded' }, { status: 400 });
+  }
+
+  if (!file.name.endsWith('.md')) {
+    return NextResponse.json({ error: 'Invalid file type' }, { status: 400 });
+  }
+
+  const bytes = await file.arrayBuffer();
+  const buffer = Buffer.from(bytes);
+  const fileName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_');
+  const slug = fileName.replace(/\.md$/, '');
+  const filePath = path.join(process.cwd(), 'src', 'content', fileName);
+  await writeFile(filePath, buffer);
+
+  const content = buffer.toString('utf8');
+  const titleLine = content.split('\n')[0] || slug;
+  const title = titleLine.replace(/^#\s*/, '') || slug;
+  addPost(slug, title, content);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import Link from 'next/link';
 
 export function Footer() {
   return (
     <footer className="mt-12 border-t bg-background">
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center text-sm text-muted-foreground">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center text-sm text-muted-foreground flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <p>&copy; {new Date().getFullYear()} StaesBlog. Built with Next.js &amp; Tailwind CSS.</p>
+        <Link href="/admin/login" className="underline hover:text-primary">Admin Login</Link>
       </div>
     </footer>
   );

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -40,6 +40,17 @@ initialPosts.forEach(post => {
   posts.set(post.slug, fullPost);
 });
 
+export function addPost(slug: string, title: string, content: string) {
+  const newPost: Post = {
+    id: Date.now().toString(),
+    title,
+    slug,
+    publishedAt: new Date(),
+    content,
+  };
+  posts.set(slug, newPost);
+}
+
 export function getPosts(): Post[] {
   return Array.from(posts.values()).sort((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
 }


### PR DESCRIPTION
## Summary
- add admin login link to footer
- implement admin login page and markdown post upload page
- support storing uploaded posts via new API route and in-memory store

## Testing
- `npm run lint` *(fails: project prompts for ESLint configuration)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68bb56543aa88328bdbc96827e4ef8f3