### PR TITLE
fix: accept markdown files regardless of extension case

### DIFF
--- a/src/app/admin/upload/page.tsx
+++ b/src/app/admin/upload/page.tsx
@@ -38,7 +38,7 @@ export default function UploadPage() {
       <form onSubmit={handleSubmit} className="space-y-4">
         <Input
           type="file"
-          accept=".md"
+          accept=".md,.markdown,text/markdown"
           onChange={(e) => setFile(e.target.files?.[0] ?? null)}
         />
         <Button type="submit" className="w-full">

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -11,7 +11,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'No file uploaded' }, { status: 400 });
   }
 
-  if (!file.name.endsWith('.md')) {
+  const ext = path.extname(file.name).toLowerCase();
+  if (!['.md', '.markdown'].includes(ext)) {
     return NextResponse.json({ error: 'Invalid file type' }, { status: 400 });
   }
 


### PR DESCRIPTION
## Summary
- handle `.md` and `.markdown` extensions case-insensitively on upload
- broaden admin upload input to accept additional markdown file types

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: interactive ESLint prompt)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68bbe41d3a5483288b0092e071f7781c